### PR TITLE
IBDesignable crash because of Animator

### DIFF
--- a/Charts/Classes/Animation/ChartAnimator.swift
+++ b/Charts/Classes/Animation/ChartAnimator.swift
@@ -306,7 +306,7 @@ public class ChartAnimator: NSObject
             if _displayLink === nil
             {
                 _displayLink = NSUIDisplayLink(target: self, selector: #selector(animationLoop))
-                _displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
+                _displayLink?.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
             }
         }
     }


### PR DESCRIPTION
I create a subclass of LineChartView and this subclass is loaded in a IBDesignable UIView (CustomView), so when I add a UIView on a StoryBoard and subclass from my CustomView it crash because it's not capable to create '_displayLink'.

---

Process:               IBDesignablesAgentCocoaTouch [94019]
Path:                  /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/Xcode/Overlays/IBDesignablesAgentCocoaTouch
Identifier:            IBDesignablesAgentCocoaTouch
Version:               7.3 (10085)
Code Type:             X86-64 (Native)
Parent Process:        Xcode [91085]
Responsible:           IBDesignablesAgentCocoaTouch [94019]
User ID:               503

Date/Time:             2016-08-18 17:41:10.752 -0500
OS Version:            Mac OS X 10.11.6 (15G31)
Report Version:        11
Anonymous UUID:        6D088489-76EE-8877-44B3-BDF36CFC1155

Time Awake Since Boot: 31000 seconds

System Integrity Protection: enabled

Crashed Thread:        0

Exception Type:        EXC_BAD_INSTRUCTION (SIGILL)
Exception Codes:       0x0000000000000001, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Application Specific Information:
CoreSimulator 209.19 - Device: IBSimDeviceTypeiPad1x - Runtime: iOS 9.3 (13E230) - DeviceType: IBSimDeviceTypeiPad1x
fatal error: unexpectedly found nil while unwrapping an Optional value

Thread 0 Crashed:
0   libswiftCore.dylib              0x000000021b6a6108 _TTSf4s_s_d_d___TFs18_fatalErrorMessageFTVs12StaticStringS_S_Su_T_ + 40
1   org.cocoapods.Charts            0x0000000219b11311 _TFC6Charts13ChartAnimator7animatefT13xAxisDurationSd6easingGSqFT7elapsedSd8durationSd_V12CoreGraphics7CGFloat__T_ + 721 (ChartAnimator.swift:265)
2   org.cocoapods.Charts            0x0000000219b1170c _TFC6Charts13ChartAnimator7animatefT13xAxisDurationSd12easingOptionOS_17ChartEasingOption_T_ + 156 (ChartAnimator.swift:277)
3   org.cocoapods.Charts            0x0000000219b11851 _TFC6Charts13ChartAnimator7animatefT13xAxisDurationSd_T_ + 65 (ChartAnimator.swift:285)
4   org.cocoapods.Charts            0x0000000219b6d525 _TFC6Charts13ChartViewBase7animatefT13xAxisDurationSd_T_ + 149 (ChartViewBase.swift:668)
